### PR TITLE
[VSCode] Replace LLDB debugger with GDB

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
          *      attached to.
          * Note:
          *   - Requires `benjamin-simmonds.pythoncpp-debug` (Python C++ Debugger)
-         *     and `vadimcn.vscode-lldb` (CodeLLDB) extension for C++ debugging.
+         *     extension for C++ debugging.
          *   - The following 1.1 and 1.2 configurations are subordinate to this configuration.
          */
         {
@@ -46,11 +46,19 @@
          */
         {
             "name": "C++: TVM Backend",
-            "type": "lldb",
+            "type": "cppdbg",
             "request": "attach",
             // Customize this to your venv python executable path
-            "program": "/opt/homebrew/Caskroom/miniconda/base/envs/tvm-build-venv/bin/python",
-            "pid": "${command:pickProcess}",
+            "program": "/home/yangjianchao/miniconda3/envs/tvm-build-venv/bin/python3",
+            "processId": "${command:pickProcess}",
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
         },
         /*
          * Configuration 2: Pure C++ Debugging.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,7 +49,7 @@
             "type": "cppdbg",
             "request": "attach",
             // Customize this to your venv python executable path
-            "program": "/home/yangjianchao/miniconda3/envs/tvm-build-venv/bin/python3",
+            "program": "/home/user/miniconda3/envs/tvm-build-venv/bin/python3",
             "processId": "${command:pickProcess}",
             "MIMode": "gdb",
             "setupCommands": [
@@ -69,16 +69,26 @@
          */
         {
             "name": "Pure C++ Debug",
-            "type": "lldb",
+            "type": "cppdbg",
             "request": "launch",
-            // Customize this to your executable path
-            "program": "${workspaceFolder}/build/oottvm_test",
+            // Customize `"program"` entry to your C++ executable path.
+            "program": "oot-tvm-example-project/build/oottvm_test",
             "args": [],
             "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
-            "env": {
-                "EXAMPLEKEY": "EXAMPLEVALUE"
-            },
-        }
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+            ],
+            "environment": [
+                {
+                    "name": "EXAMPLEKEY",
+                    "value": "EXAMPLEVALUE"
+                }
+            ]
+        },
     ],
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TVM specific GDB commands and LLDB debugging configuration in VSCode​
+# TVM specific GDB commands and GDB debugging configuration in VSCode​
 
 ## 1. TVM specific GDB commands
 
@@ -99,22 +99,19 @@ This extension adds 4 new commands to gdb that improve the experience of debuggi
     alias tvf = tvm_fields
     ```
 
-## 2. LLDB debugging configuration in VSCode​
+## 2. GDB debugging configuration in VSCode​
 
-The `.vscode/launch.json` configuration enables hybrid debugging of TVM's Python frontend (Python debugger) and C++ backend (LLDB) in VSCode.
-
-> [!WARNING]
-> Our current configuration only supports LLDB debugging. Please ensure you have LLDB installed on your system. We will subsequently provide some LLDB command scripts to assist with debugging.
+The `.vscode/launch.json` configuration enables hybrid debugging of TVM's Python frontend (Python debugger) and C++ backend (GDB) in VSCode.
 
 ### 2.1 Required VSCode Extensions
 
 Before using this configuration to debug TVM, we should install the following extensions for VSCode:
 
- - [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb): Search `vadimcn.vscode-lldb` in VSCode extension marketplace.
+ - [Python Debugger](https://marketplace.visualstudio.com/items?itemName=ms-python.debugpy): Search `ms-python.debugpy` in VSCode extension marketplace.
+ - [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools): Search `ms-vscode.cpptools` in VSCode extension marketplace.
  - [​Python C++ Debugger​​](https://marketplace.visualstudio.com/items?itemName=benjamin-simmonds.pythoncpp-debug): Search `benjamin-simmonds.pythoncpp-debug` in VSCode extension marketplace.
- - [LLDB DAP](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.lldb-dap): Search `llvm-vs-code-extensions.lldb-dap` in VSCode extension marketplace.
 
-After installing the extensions, we should copy the `.vscode/launch.json` file to the root directory of your own project. And the next steps will explain some details that you should modify in the `launch.json` file.
+After installing the extensions, we should copy the `.vscode/launch.json` file to the root directory of your own TVM project. And the next steps will explain some details that you should modify in the `launch.json` file.
 
 ### 2.2 Debugging Modes​ and Usage
 
@@ -138,7 +135,7 @@ This is a hybrid debugging approach, and requires users to first launch the Pyth
 > [!IMPORTANT]  
 > Customize the `"program"` entry in `.vscode/launch.json` to point to your Python virtual environment executable.  
 > Example path:
-> `"program": "/opt/homebrew/Caskroom/miniconda/base/envs/tvm-build-venv/bin/python"`
+> `"program": "/home/user/miniconda3/envs/tvm-build-venv/bin/python3"`
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ As the fowllowing image shows, we can choose the debugging mode in graphical int
 This is a hybrid debugging approach, and requires users to first launch the Python script, after which the C++ process will be automatically attached.
 
 > [!IMPORTANT]  
-> Customize the `"program"` entry in `.vscode/launch.json` to point to your Python virtual environment executable.  
-> Example path:
-> `"program": "/home/user/miniconda3/envs/tvm-build-venv/bin/python3"`
+> Customize the `"program"` entry in `.vscode/launch.json` to point to your Python virtual environment executable. Example path:
+> > `"program": "/home/user/miniconda3/envs/tvm-build-venv/bin/python3"`
+>
+> Commands that interact with the Debug Console should be preceded by `-exec`, example:
+> > `-exec p pc` or `-exec call tvm::Dump(mod)`
 
 Example:
 
@@ -148,7 +150,7 @@ This is a pure C++ debugging approach, where users can debug C++ components with
 > [!IMPORTANT]  
 > Customize the `"program"` entry in `.vscode/launch.json` to your C++ executable path.
 > Example path:  
-> `"program": "${workspaceFolder}/get_started/tutorials/a.out"`
+> > `"program": "${workspaceFolder}/get_started/tutorials/a.out"`
 
 Example:
 


### PR DESCRIPTION
Replace LLDB debugger in VSCode settings.json with GDB to avoid the bug that LLDB prints some TVM variables.

Co-authored-by: BenkangPeng <benkangpeng@163.com>